### PR TITLE
CI: Automatic examples updating

### DIFF
--- a/.github/workflows/update_readme.yml
+++ b/.github/workflows/update_readme.yml
@@ -1,0 +1,21 @@
+name: Update README
+
+on:
+  push:
+    branches:
+      - master
+    paths:
+      - 'examples/**'
+
+jobs:
+  embed-code:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Markdown autodocs
+        uses: dineshsonachalam/markdown-autodocs@v1.0.4
+        with:
+          commit_message: 'docs: update code examples'
+          # Optional output file paths, defaults to '[./README.md]'.
+          output_file_paths: '[./README.md]'
+          categories: '[code-block]'

--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ The Neovim package specification supports a single, top-level package metadata f
 
 # Example
 
+<!-- MARKDOWN-AUTO-DOCS:START (CODE:src=/examples/packspec.1.lua) -->
 ```lua
 package = "lspconfig"
 version = "0.1.2"
@@ -86,8 +87,10 @@ external_dependencies = {
    },
 }
 ```
+<!-- MARKDOWN-AUTO-DOCS:END -->
 
 And in json format
+<!-- MARKDOWN-AUTO-DOCS:START (CODE:src=/examples/packspec.1.json) -->
 ```json
 {
   "package" : "lspconfig",
@@ -117,6 +120,7 @@ And in json format
   }
 }
 ```
+<!-- MARKDOWN-AUTO-DOCS:END -->
 
 # Guidelines for `packspec` implementers
 


### PR DESCRIPTION
A bit of CI to update the docs, and also update the readme with the new fields I added.
The workflow will update the code blocks we have as examples with the respective filename.

Example: https://github.com/muniter/nvim-package-specification last commit

Note: This only updates the example code blocks